### PR TITLE
Adding support for vue-html language

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
             {
                 "language": "vue",
                 "path": "./snippets/vue.json"
+            },
+            {
+                "language": "vue-html",
+                "path": "./snippets/vue.json"
             }
         ]
     }


### PR DESCRIPTION
Single file components seem to use vue-html for the language in the template section. This PR adds support for loading snippets in that section.

This addresses the feature request here: https://github.com/adrian273/buefy-snippet/issues/1